### PR TITLE
Use deploy directive instead of after_success

### DIFF
--- a/.bin/deploy.sh
+++ b/.bin/deploy.sh
@@ -2,16 +2,6 @@
 
 set -e
 
-if [[ "false" != "$TRAVIS_PULL_REQUEST" ]]; then
-  echo "Not deploying pull requests."
-  exit
-fi
-
-if [[ "master" != "$TRAVIS_BRANCH" ]]; then
-  echo "Not on the 'master' branch."
-  exit
-fi
-
 rm -rf .git
 rm -r .gitignore
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,13 @@ script:
   - ls -al style.css
   - npm test
 
-after_success: bash ./.bin/deploy.sh
+deploy:
+  provider: script
+  script: .bin/deploy.sh
+  skip_cleanup: true
+  on:
+    branch: master
+    php: 7
 
 env:
   global:


### PR DESCRIPTION
**AN EXPERIMENTAL PR**

I prefer to use deploy directive but I'm not sure which this change correctly works or not.
https://docs.travis-ci.com/user/deployment#Conditional-Releases-with-on%3A

Now deploy.sh may be too danger because it can break git repo everywhere.
